### PR TITLE
Clarify what bot will do when WIP is included in title

### DIFF
--- a/responses/01_defining-webhooks-apis.md
+++ b/responses/01_defining-webhooks-apis.md
@@ -1,5 +1,5 @@
 ## WIP response
-When you added "WIP" to the title of this pull request, something changed. Do you see that this pull request is now blocked from merging?
+When you added "WIP" to the title of this pull request, something changed. Do you see that the pull request's status is "pending" with and yellow dot? This is to block merging while the title includes "WIP".
 
 Here's what's happening under-the-hood with the WIP app.
 


### PR DESCRIPTION
This PR resolves #27 by clarifying that the bot won't block it and make it red, but make it yellow, and include reasoning. 