### PR TITLE
Try to put error message in escaped place

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,6 +47,7 @@ steps:
         left: '/\WIP/g'
         operator: '!test'
         right: '%payload.pull_request.title%'
+        else: 
         - type: respond
           with: 02_WIP-error-message2.md
       - type: respond


### PR DESCRIPTION
I think the "else" is functioning as an escape, so the user does the right thing and the course stops working. I'm trying to flip that, but may need to experiment with the "operator" part of the "gate". 