### PR TITLE
Don't fail step

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -168,14 +168,12 @@ steps:
         left: 'POST /repos/:owner/:repo/labels'
         operator: test
         right: '%payload.comment.body%'
+        required: false
         else:
-          - type: removeBranchProtection
-          - type: mergePullRequest
-            pullRequest: 3
           - type: respond
             with: replace-api-comment-error.md
             data:
-             repoUrl: '%payload.repository.html_url%'
+              repoUrl: '%payload.repository.html_url%'
       - type: removeBranchProtection
       - type: mergePullRequest
         pullRequest: 3


### PR DESCRIPTION
Setting `required: false` on a gate means that even if it resolves to falsy, the next action will run and the step can be completed. I removed the first removeBranchProtection and mergePullRequest, because they'll be run later anyway.