### PR TITLE
Prevent double post

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -185,7 +185,7 @@ steps:
         pullRequest: 3
       - type: gate
         left: 'POST /repos/:owner/:repo/labels'
-        operator: !test
+        operator: '!test'
         right: '%payload.comment.body%'
         required: false
         else:


### PR DESCRIPTION
Prevents double posts from `required: false` gates

This resolves #113 and #112 