### PR TITLE
Specify Content-type: application/json

### DIFF
--- a/responses/02_adding-smee.md
+++ b/responses/02_adding-smee.md
@@ -20,6 +20,7 @@ For the next exercise, let's add our own notification service to get a better id
 1. Copy your unique "Webhook Proxy URL"
 1. In [your webhooks settings]({{ repoUrl }}/settings/hooks), click **Add webhook**
 1. Paste your unique smee.io URL in the "Payload URL" field
+1. Choose `application/json` in the **Content type** dropdown
 1. Leave the "Secret" field blank
 1. For "Which events would you like to trigger this webhook?", select **Send me everything**
 1. Click **Add webhook**


### PR DESCRIPTION
Setting this **Content type** to `application/json` (`application/x-www-form-encoded` is the default) is helpful, because Smee won't be able to parse the payload and show it in its UI. It's not mandatory, you'll still see the event show up in Smee, but with a lot less detail. This is more of a Smee "bug" (though really its a missing feature) than anything else.

| `/json` | `/x-www-form-encoded` |
| --- | --- |
| <img width="730" alt="image" src="https://user-images.githubusercontent.com/10660468/46894943-470e0800-ce44-11e8-81ad-65448cb8326d.png"> | <img width="742" alt="image" src="https://user-images.githubusercontent.com/10660468/46894952-50977000-ce44-11e8-9413-1ced26aa6afc.png"> |

<img width="620" alt="image" src="https://user-images.githubusercontent.com/10660468/46894985-7cb2f100-ce44-11e8-8059-c07306c6a441.png">
