### PR TITLE
Update deprecated Octokit methods

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -162,7 +162,7 @@ steps:
     link: '{{ repoUrl }}/pull/3'
     actions:
       - type: octokit
-        method: pullRequests.getFiles
+        method: pullRequests.listFiles
         owner: '%payload.repository.owner.login%'
         repo: '%payload.repository.name%'
         number: '%payload.pull_request.number%'

--- a/config.yml
+++ b/config.yml
@@ -52,7 +52,7 @@ steps:
     link: '{{ repoUrl }}/pull/2'
     actions:
       - type: octokit
-        method: repos.getHooks
+        method: repos.listHooks
         owner: '%payload.repository.owner.login%'
         repo: '%payload.repository.name%'
         action_id: hooks


### PR DESCRIPTION
These two methods in the `octokit` action have been deprecated in version 16, so we need to update these. We don't have equivalent actions for these, so I've just updated them for now to unblock our upgrade path.