### PR TITLE
Replace developer.github.com with docs.github.com

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -185,7 +185,7 @@ steps:
     link: '{{ repoUrl }}/pull/3'
     actions:
       - type: gate
-        left: 'POST /repos/:owner/:repo/labels'
+        left: 'POST /repos/{owner}/{repo}/labels'
         operator: test
         right: '%payload.comment.body%'
         required: false
@@ -198,7 +198,7 @@ steps:
       - type: mergePullRequest
         pullRequest: 3
       - type: gate
-        left: 'POST /repos/:owner/:repo/labels'
+        left: 'POST /repos/{owner}/{repo}/labels'
         operator: '!test'
         right: '%payload.comment.body%'
         required: false

--- a/responses/02_adding-smee.md
+++ b/responses/02_adding-smee.md
@@ -3,7 +3,7 @@ Nice job! Something changed on this repo when you added the "WIP" command. Let's
 ## Breaking down the WIP app components
 
 - **Electricity**: Since this is a Probot app, the power to run comes from deployment, set up by the app creators. We don't need to worry about this until we build an app ourselves.
-- **Standard behaviors**: GitHub has a list of [documented events](https://developer.github.com/webhooks/#events) that can alert an app.
+- **Standard behaviors**: GitHub has a list of [documented events](https://docs.github.com/en/developers/webhooks-and-events/about-webhooks#events) that can alert an app.
 - **Location**: Apps are designed to look for pre-determined events in whichever repositories they've been installed. On installation, it has to ask permission for each event type that it wants to monitor.
 - **Notification service**: If the expected action occurs, a notification delivery is sent to the app as a webhook payload -- a specific set of data transmitted via GitHub's API.
 

--- a/responses/03_discovering-api-endpoints.md
+++ b/responses/03_discovering-api-endpoints.md
@@ -16,7 +16,7 @@ When an event is triggered, the vastly more detailed GitHub API gives the bot an
 
 ### :keyboard: Activity: Discovering endpoints
 
-1. Navigate to [this list](https://developer.github.com/v3/apps/available-endpoints/)
+1. Navigate to [this list](https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps)
 2. Find the endpoint that an app would use to create a label
 3. Post that endpoint as a comment
 

--- a/responses/03_endpoint-comment-error.md
+++ b/responses/03_endpoint-comment-error.md
@@ -1,4 +1,4 @@
-Nice try! The label creation endpoint, found [here](https://developer.github.com/v3/issues/labels/#create-a-label), looks like this: `POST /repos/:owner/:repo/labels`.
+Nice try! The label creation endpoint, found [here](https://docs.github.com/en/rest/reference/issues#create-a-label), looks like this: `POST /repos/{owner}/{repo}/labels`.
 
 ## APIs and Webhooks
 APIs and Webhooks go hand in hand, but the distinction between them is important.


### PR DESCRIPTION
A few responses in the course point to the developer.github.com portal, where learners might have to again follow the link at the top of the page to go to docs.github.com. This PR changes references from developer.github.com to docs.github.com and points to the right page. It also modifies the `Identify API Endpoints` step to look for a comment that matches endpoints as they are listed on docs.github.com

cc: @pauliver 