### PR TITLE
Rename master to main in all instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ For more information on the goals of this course, check out the [`course-details
 
 ## Contribute
 
-See something we could improve? Check out the contributing guide in the [community contributors repository](https://github.com/githubtraining/community-contributors/blob/master/CONTRIBUTING.md) for more information on the types of contributions we :heart: and instructions.
+See something we could improve? Check out the contributing guide in the [community contributors repository](https://github.com/githubtraining/community-contributors/blob/main/CONTRIBUTING.md) for more information on the types of contributions we :heart: and instructions.
 
-We :heart: our community and take great care to ensure it is fun, safe and rewarding. Please review our [Code of Conduct](https://github.com/githubtraining/community-contributors/blob/master/CODE_OF_CONDUCT.md) for community expectations and guidelines for reporting concerns.
+We :heart: our community and take great care to ensure it is fun, safe and rewarding. Please review our [Code of Conduct](https://github.com/githubtraining/community-contributors/blob/main/CODE_OF_CONDUCT.md) for community expectations and guidelines for reporting concerns.
 
 ## License
 


### PR DESCRIPTION
This pull request changes references to the `master` branch to the `main` branch.

Once this is ready to merge, I will:

- [x] Rename the default branch in this repository
- [x] Update any other PRs in this repository
- [x] Rename the default branch in the [template repository](https://github.com/githubtraining/caption-this-template)
- [ ] Merge this PR
- [x] Test to make sure things work as expected

cc @githubtraining/programs