### PR TITLE
Remove misleading detail about target endpoint in instructions for "Discovering Endpoints"

### DIFF
--- a/responses/03_discovering-api-endpoints.md
+++ b/responses/03_discovering-api-endpoints.md
@@ -17,7 +17,7 @@ When an event is triggered, the vastly more detailed GitHub API gives the bot an
 ### :keyboard: Activity: Discovering endpoints
 
 1. Navigate to [this list](https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps)
-2. Find the endpoint that an app would use to create a label on an Issue
+2. Find the endpoint that an app would use to create a label
 3. Post that endpoint as a comment
 
 <hr>


### PR DESCRIPTION
The instructions to this "Discovering Endpoints" step indicate you should find the endpoint that is used to create a label _on an Issue_:
<img width="526" alt="image" src="https://user-images.githubusercontent.com/2475919/160245074-5dbb45ae-05df-4dc8-bf79-8528c4262de0.png">

I interpreted this as meaning the one used to _add_ a label to an Issue, and that was incorrect: the configured solution to this step in the course expects you to provide the endpoint that you'd use to create a label, period.
<img width="919" alt="image" src="https://user-images.githubusercontent.com/2475919/160245082-1dddaed3-a8b4-40bb-a419-69e20346405c.png">

Since Issues don't factor into this at all, I'm proposing a clarification on the instructions.