### PR TITLE
Replace misleading word in course details: 'implementing' -> 'integrating'

### DIFF
--- a/course-details.md
+++ b/course-details.md
@@ -19,7 +19,7 @@ And when you're done you'll be able to:
 
 
 ## What you'll build
-In this course, we'll be implementing several GitHub Apps, introducing the GitHub APIs, and learning how to utilize webhooks:
+In this course, we'll be integrating several GitHub Apps, introducing the GitHub APIs, and learning how to utilize webhooks:
 
 ![smee](https://user-images.githubusercontent.com/57373296/75803842-125a6380-5d4d-11ea-9bef-8b317d1ab300.gif)
 


### PR DESCRIPTION
The current course details say that:
>In this course, we'll be **implementing** several GitHub Apps...

(emphasis mine)

But I just took this course, and that is not true: we _integrated_ a few apps, but we did not implement any. This PR proposes we tweak the language to match what we actually do in the course:
>In this course, we'll be **integrating** several GitHub Apps...
